### PR TITLE
Add default & parameter tags to resource groups for Azure Policy compliance

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -25,6 +25,11 @@
     },
     "aiFoundryResourceName": {
       "value": "${AI_FOUNDRY_RESOURCE_NAME}"
+    },
+    "tags": {
+      "value": {
+       
+      }
     }
   }
 }


### PR DESCRIPTION
# Problem

When installing this stack (infra + code) in my Azure tenant, my organization enforces an Azure Policy that requires specific tags to be present in resource groups. This caused deployment errors due to missing required tags.

# Solution

I modified the Bicep template by adding a line to ensure resource groups always include both the default tags and any tags supplied as parameters. This update allows the deployment to succeed in environments where Azure Policies mandate tagging.

## Details

- Combines default tags with parameter-supplied tags in the Bicep file `infra/main.bicep`.
- Ensures compatibility with organizational policies requiring tagging during resource group creation.

# Testing

- Verified deployment succeeds with Azure Policy enforcing tag requirements.
- Existing deployments without policy enforcement are unaffected.

# Impact

This change helps organizations with mandatory Azure tagging policies successfully deploy the stack.
